### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,18 +18,18 @@
     "test": "lab -a code -t 100 -v -m 60000 -L -r json -o test.lab -r html -o test.html -r console -o stdout -r console -o test.log"
   },
   "dependencies": {
+    "angler": "git+https://github.com/fishin/angler.git",
+    "bait": "git+https://github.com/fishin/bait.git",
     "boom": "2.x.x",
+    "fillet": "git+https://github.com/fishin/fillet.git",
+    "fishhook": "git+https://github.com/fishin/fishhook.git",
     "hapi": "13.x.x",
     "hoek": "3.x.x",
     "inert": "3.x.x",
     "joi": "6.x.x",
-    "node-uuid": "1.x.x",
-    "angler": "git+https://github.com/fishin/angler.git",
-    "bait": "git+https://github.com/fishin/bait.git",
-    "fillet": "git+https://github.com/fishin/fillet.git",
-    "fishhook": "git+https://github.com/fishin/fishhook.git",
     "pail": "git+https://github.com/fishin/pail.git",
     "reel": "git+https://github.com/fishin/reel.git",
+    "uuid": "^3.0.0",
     "vision": "3.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.